### PR TITLE
Catch TypeError when serializing to JSON

### DIFF
--- a/stacklogging/main.py
+++ b/stacklogging/main.py
@@ -52,7 +52,11 @@ def format_stackdriver_json(record, message):
     extra_keys = get_extra_keys(record)
 
     for key in extra_keys:
-        payload[key] = record.__dict__[key]
+        try:
+            json.dumps(record.__dict__[key])  # serialization/type error check
+            payload[key] = record.__dict__[key]
+        except TypeError:
+            payload[key] = str(record.__dict__[key])
 
     return json.dumps(payload)
 


### PR DESCRIPTION
Some objects may not be serializable to JSON so we can't put the entire object into the payload. We'll handle/catch using their string representation instead.