### PR TITLE
Allow custom Formatter

### DIFF
--- a/stacklogging/__init__.py
+++ b/stacklogging/__init__.py
@@ -2,12 +2,15 @@ from stacklogging.main import StackloggingHandler
 import logging
 
 
-def getLogger(name=None, level=logging.DEBUG):
+def getLogger(name=None, level=logging.DEBUG, formatter=None):
     logger = logging.getLogger(name)
     logger.setLevel(level)
 
     logger_handler = StackloggingHandler()
     logger_handler.setLevel(level)
+    if formatter:
+        logger_handler.setFormatter(formatter)
+
     logger.addHandler(logger_handler)
 
     return logger


### PR DESCRIPTION
Allow for customizing the format of the error messages:

```python
import logging
import stacklogging


formatter = logging.Formatter("[%(levelname)s] [%(name)s:%(lineno)s - %(funcName)s() ] %(message)s")
logger = stacklogging.getLogger(name, level=logging.DEBUG, formatter=formatter)
```